### PR TITLE
Reordered CvMat and IplImage struct fields to match C data structures.

### DIFF
--- a/cv-types.lisp
+++ b/cv-types.lisp
@@ -187,40 +187,47 @@
 ;;; 
 ;;; CvMat
 (cffi:defcstruct mat
-  (height :int)
-  (width :int)
-  (data :pointer)
-  (hdr_refcount :int)
-  (refcount :pointer)
+  (type :int)
   (step :int)
-  (type :int))
+  (refcount :pointer)
+  (hdr-refcount :int)
+  (data :pointer)
+  (height :int)
+  (width :int))
 
 
 ;;; IplImage
 (cffi:defcstruct ipl-image
-  (align :int)
-  (alpha-channel :int)
-  (border-const :int :count 4)
-  (border-mode :int :count 4)
-  (channel-seq :char :count 4)
-  (color-model :char :count 4)
-  (data-order :int)
-  (depth :int)
-  (height :int)
-  (id :int)
-  (image-data :pointer)
-  (image-data-origin :pointer)
-  (image-id :pointer)
-  (image-size :int)
-  (mask-roi :pointer)
-  (n-channels :int)
   (n-size :int)
-  (origin :int)
-  (roi :pointer)
-  (tile-info :pointer)
-  (width :int)
-  (width-step :int))
+  (id :int)
+  (n-channels :int)
+  (alpha-channel :int)
+  (depth :int)
 
+  (color-model :char :count 4)
+  (channel-seq :char :count 4)
+  (data-order :int)
+
+  (origin :int)
+
+  (align :int)
+
+  (width :int)
+  (height :int)
+
+  (roi :pointer)
+  (mask-roi :pointer)
+
+  (image-id :pointer)
+  (tile-info :pointer)
+
+  (image-size :int)
+
+  (image-data :pointer)
+  (width-step :int)
+  (border-mode :int :count 4)
+  (border-const :int :count 4)
+  (image-data-origin :pointer))
 
 
 ;; 

--- a/extensions.lisp
+++ b/extensions.lisp
@@ -104,6 +104,27 @@
   (cffi:with-foreign-slots ((data) mat (:struct mat))
     data))
 
+(defun ipl-data (ipl)
+  (cffi:with-foreign-slots ((image-data) ipl (:struct ipl-image))
+    image-data))
+
+
+(defun ipl-width (ipl)
+  (cffi:with-foreign-slots ((width) ipl (:struct ipl-image))
+    width))
+
+(defun ipl-width-step (ipl)
+  (cffi:with-foreign-slots ((width-step) ipl (:struct ipl-image))
+    width-step))
+
+(defun ipl-height (ipl)
+  (cffi:with-foreign-slots ((height) ipl (:struct ipl-image))
+    height))
+
+(defun ipl-data-origin (ipl)
+  (cffi:with-foreign-slots ((image-data-origin) ipl (:struct ipl-image))
+    image-data-origin))
+
 (defun get-total (seq)
   (cffi:with-foreign-slots ((total) seq (:struct seq))
     total))

--- a/package.lisp
+++ b/package.lisp
@@ -62,6 +62,12 @@
    #:width
    #:height
    #:mat-data
+   #:ipl-data
+   #:ipl-data-origin
+   #:ipl-width
+   #:ipl-width-step
+   #:ipl-height
+
    #:get-total
    #:get-seq-elem-rect
    #:with-named-window


### PR DESCRIPTION
Reordered fields in CvMat and IplImage to match the C structure so I can access the image-data pointer.

I also added a couple of extension functions for accessing IplImage fields.